### PR TITLE
WiP: Build java using GraalVM on the sfdk target

### DIFF
--- a/java-part/compile.sh
+++ b/java-part/compile.sh
@@ -1,10 +1,29 @@
 #!/bin/bash
-COMPILEHOST=phone2
-COMPILEHOST_WORKSPACE=dev/java-part
-COMPILEHOST_GRAAL=/home/defaultuser/dev/graalvm-ce-java17-22.2.0
-echo "transfering data"
-rsync . $COMPILEHOST:$COMPILEHOST_WORKSPACE -r
+# Stop on error
+set -e
+
+# Use 'sfdk tools target list' to find the correct target
+SFDK_TARGET=SailfishOS-4.4.0.58-aarch64
+
+# The location of the 'sailing-the-flood-to-java' folder
+PROJECT_ROOT=$PWD/..
+COMPILEHOST_WORKSPACE=$PROJECT_ROOT/java-part
+COMPILEHOST_GRAAL=$PROJECT_ROOT/java-part/graalvm-ce-java17-22.2.0
+
+# Extract the location of the sfdk binary
+SFDK=`xmllint --xpath "/qtcreator/data/variable[contains(text(), 'BuildEngines.InstallDir')]/parent::data/value/text()" ~/.config/SailfishSDK/libsfdk/buildengines.xml`/bin/sfdk
+
 echo "starting compilation"
-ssh $COMPILEHOST "cd $COMPILEHOST_WORKSPACE; GRAALVM_HOME=$COMPILEHOST_GRAAL JAVA_HOME=$COMPILEHOST_GRAAL ./mvnw clean install -Pnative"
-scp $COMPILEHOST:"$COMPILEHOST_WORKSPACE/target/*.h" ../qt-part/lib/
-scp $COMPILEHOST:"$COMPILEHOST_WORKSPACE/target/javafloodjava.so" ../qt-part/lib/libjavafloodjava.so
+echo "Target: $SFDK_TARGET"
+cd "$COMPILEHOST_WORKSPACE"
+
+# Restrict JVM memory usage; this is a QEMU limitation
+echo "-Xmx1024m -XX:-UseCompressedClassPointers" > .mvn/jvm.config
+
+# Let's go...
+$SFDK engine exec sb2 -t $SFDK_TARGET ./target-commands.sh $COMPILEHOST_GRAAL $COMPILEHOST_GRAAL
+
+cp "$COMPILEHOST_WORKSPACE/target/*.h" "$PROJECT_ROOT/qt-part/lib/"
+cp "$COMPILEHOST_WORKSPACE/target/sailfishjava.so" "$PROJECT_ROOT/qt-part/lib/libsailfishjava.so"
+
+

--- a/java-part/pom.xml
+++ b/java-part/pom.xml
@@ -17,6 +17,16 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12.4</version>
+                <configuration>
+                    <forkCount>3</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>-Xmx1024m -XX:-UseCompressedClassPointers</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.0.0</version>
@@ -91,6 +101,9 @@
                             <mainClass>Main</mainClass>
                             <buildArgs>
                                 <buildArg>
+                                    -J-Xmx1024m
+                                    -J-Xms1024m
+                                    -J-XX:-UseCompressedClassPointers
                                     -H:ReflectionConfigurationFiles=${project.basedir}/src/main/resources/reflectorconfig.json
                                     --no-fallback
                                     --shared

--- a/java-part/target-commands.sh
+++ b/java-part/target-commands.sh
@@ -1,0 +1,6 @@
+echo "Compiloe workspace: $1"
+echo "Java home: $2"
+echo
+echo "Brace yourself: this will take some time."
+COMPILEHOST_WORKSPACE=$1 JAVA_HOME=$2 ./mvnw clean install -Pnative
+


### PR DESCRIPTION
This is a proof-of-concept, not working code to be merged.

Reworks the compile script to build the java source on a local GraalVM inside an sfdk target, rather than on a remote device.

The changes add restrictions to the amount of heap the JVM can allocate. This is necessary to appease the QEMU version used by the sfdk build engine.

The memory restrictions unfortunately prevent the build from going through, so this is a proof-of-concept rather than a working solution.